### PR TITLE
Use snmalloc for datafusion

### DIFF
--- a/datafusion/Cargo.lock
+++ b/datafusion/Cargo.lock
@@ -216,6 +216,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb6210b637171dfba4cda12e579ac6dc73f5165ad56133e5d72ef3131f320855"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -275,7 +284,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "4.0.0-SNAPSHOT"
-source = "git+https://github.com/apache/arrow-datafusion?branch=master#aa26112525164a81c28f879c80e650452e396306"
+source = "git+https://github.com/apache/arrow-datafusion?branch=master#2f73558b6ed68974f2b63d64bef4628b0776d3d5"
 dependencies = [
  "ahash",
  "arrow",
@@ -305,10 +314,8 @@ dependencies = [
 name = "datafusion_playground"
 version = "0.1.0"
 dependencies = [
- "csv",
  "datafusion",
- "glob",
- "rand 0.8.3",
+ "snmalloc-rs",
  "tokio",
 ]
 
@@ -486,12 +493,6 @@ dependencies = [
  "libc",
  "wasi 0.10.2+wasi-snapshot-preview1",
 ]
-
-[[package]]
-name = "glob"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "hashbrown"
@@ -851,9 +852,9 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a152013215dca273577e18d2bf00fa862b89b24169fb78c4c95aeb07992c9cec"
+checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
 dependencies = [
  "unicode-xid",
 ]
@@ -1068,6 +1069,24 @@ name = "snap"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45456094d1983e2ee2a18fdfebce3189fa451699d0502cb8e3b49dba5ba41451"
+
+[[package]]
+name = "snmalloc-rs"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f5a6194d59b08fc87381e7c8a04ab4ab9967282b00f409bb742e08f3514ed0b"
+dependencies = [
+ "snmalloc-sys",
+]
+
+[[package]]
+name = "snmalloc-sys"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9518813a25ab2704a6df4968f609aa6949705409b6a854dcc87018d12961cbc8"
+dependencies = [
+ "cmake",
+]
 
 [[package]]
 name = "sqlparser"

--- a/datafusion/Cargo.toml
+++ b/datafusion/Cargo.toml
@@ -8,11 +8,9 @@ edition = "2018"
 
 [dependencies]
 tokio = "^1.5.0"
-rand = "^0.8.3"
-csv = "^1.1.6"
-glob = "^0.3.0"
 # datafusion has unreleased bug fixes on joins that are necessary. Needs custom version of arrow to function
 datafusion = { git = "https://github.com/apache/arrow-datafusion", branch = "master" }
+snmalloc-rs = {version = "0.2", features= ["cache-friendly"]}
 
 [profile.release]
 debug = true


### PR DESCRIPTION
And cleanup some unused dependencies.

I cannot run the example, but this often improves performance a bit.